### PR TITLE
Rest Framework 3.6+ routers fix

### DIFF
--- a/hammock/routers.py
+++ b/hammock/routers.py
@@ -10,10 +10,13 @@ from rest_framework.settings import api_settings
 class NonDefaultPermissionApiRootRouter(routers.DefaultRouter):
     """Router with a permission different from the default for the root."""
 
-    def __init__(self, trailing_slash=True, root_view_permission_classes=None):
+    def __init__(self, *args, **kwargs):
         """Initialize router."""
-        super(NonDefaultPermissionApiRootRouter, self).__init__(
-            trailing_slash=trailing_slash)
+        root_view_permission_classes = kwargs.pop(
+            'root_view_permission_classes', None)
+
+        super(
+            NonDefaultPermissionApiRootRouter, self).__init__(*args, **kwargs)
 
         self.root_view_permission_classes = (
             root_view_permission_classes or

--- a/hammock/routers.py
+++ b/hammock/routers.py
@@ -37,4 +37,5 @@ class NonDefaultPermissionApiRootRouter(routers.DefaultRouter):
             # the permission for the root view; set to allow anyone access
             permission_classes = self.root_view_permission_classes
 
-        return ApiRoot.as_view(**api_root_view.initkwargs)
+        as_view_kwargs = getattr(api_root_view, 'initkwargs', {})
+        return ApiRoot.as_view(**as_view_kwargs)

--- a/hammock/routers.py
+++ b/hammock/routers.py
@@ -37,4 +37,4 @@ class NonDefaultPermissionApiRootRouter(routers.DefaultRouter):
             # the permission for the root view; set to allow anyone access
             permission_classes = self.root_view_permission_classes
 
-        return ApiRoot.as_view()
+        return ApiRoot.as_view(**api_root_view.initkwargs)


### PR DESCRIPTION
`rest_framework` version 3.6 introduced an `api_root_dict` argument to the `APIRootView`'s `__init__` method (`as_view` method in the case of Django's class-based views).  This change adds support for passing to the subclass' `as_view` call whatever keyword arguments (`initkwargs`) were passed to the same method of the original API root view class.