### PR TITLE
Updates to support django 4.2 upgrade for backend services

### DIFF
--- a/hammock/metadata.py
+++ b/hammock/metadata.py
@@ -93,7 +93,7 @@ class SimplerMetadata(metadata.SimpleMetadata):
         for attr in attrs:
             value = getattr(field, attr, None)
             if value is not None and value != '':
-                field_info[attr] = force_text(value, strings_only=True)
+                field_info[attr] = force_str(value, strings_only=True)
 
         if getattr(field, 'child', None):
             field_info['child'] = self.get_field_info(field.child)
@@ -105,7 +105,7 @@ class SimplerMetadata(metadata.SimpleMetadata):
             field_info['choices'] = [
                 {
                     'value': choice_value,
-                    'display_name': force_text(choice_name, strings_only=True)
+                    'display_name': force_str(choice_name, strings_only=True)
                 }
                 for choice_value, choice_name in field.choices.items()
             ]
@@ -163,7 +163,7 @@ class StateTransitioningFieldMetadataMixin(object):
         for choice_value, choice_name in field.choices.items():
             choice = OrderedDict([
                 ('value', choice_value),
-                ('display_name', force_text(choice_name, strings_only=True)),
+                ('display_name', force_str(choice_name, strings_only=True)),
             ])
 
             # Set choice validity conditions for `state` field
@@ -327,7 +327,7 @@ class PolymorphicSerializerMetadata(ObjectSpecificMetadata):
             _choices = []
             for choice_value, _choice_info in choices.items():
                 # Set choice `value` and `display_name` attributes
-                choice_name = force_text(_choice_info[0][1], strings_only=True)
+                choice_name = force_str(_choice_info[0][1], strings_only=True)
                 choice = OrderedDict([
                     ('value', choice_value),
                     ('display_name', choice_name),

--- a/hammock/metadata.py
+++ b/hammock/metadata.py
@@ -6,7 +6,7 @@ from collections import OrderedDict
 
 from django.core.exceptions import PermissionDenied
 from django.http import Http404
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 from rest_framework import exceptions
 from rest_framework import metadata

--- a/hammock/validators.py
+++ b/hammock/validators.py
@@ -47,6 +47,7 @@ class ValueTransitionValidator(object):
 
     """
 
+    requires_context = True
     message = _(
         'Cannot transition from "{0}" to "{1}". '
         'Valid transitions for "{0}" are: [{2}].')
@@ -97,8 +98,9 @@ class ValueTransitionValidator(object):
         # return list of values `current_value` can transition to
         return [t[0] for t in self.value_transitions if current_value in t[1]]
 
-    def __call__(self, value):
+    def __call__(self, value, serializer_field):
         """Run the validation."""
+        self.set_context(serializer_field)
         current_value = getattr(self.instance, self.field_name, None)
 
         valid_value_transitions = self._get_valid_value_transitions(

--- a/hammock/validators.py
+++ b/hammock/validators.py
@@ -99,9 +99,7 @@ class ValueTransitionValidator(object):
 
     def __call__(self, value):
         """Run the validation."""
-        current_value = None
-        if self.instance:
-            current_value = getattr(self.instance, self.field_name, None)
+        current_value = getattr(self.instance, self.field_name, None)
 
         valid_value_transitions = self._get_valid_value_transitions(
             current_value)

--- a/hammock/validators.py
+++ b/hammock/validators.py
@@ -99,7 +99,9 @@ class ValueTransitionValidator(object):
 
     def __call__(self, value):
         """Run the validation."""
-        current_value = getattr(self.instance, self.field_name, None)
+        current_value = None
+        if self.instance:
+            current_value = getattr(self.instance, self.field_name, None)
 
         valid_value_transitions = self._get_valid_value_transitions(
             current_value)

--- a/hammock/validators.py
+++ b/hammock/validators.py
@@ -1,7 +1,7 @@
 """Validator classes for serializers and serializer fields."""
 
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.translation import ugettext_lazy as _
+from django.utils.translation import gettext_lazy as _
 
 from rest_framework.exceptions import ValidationError
 from rest_framework.utils.representation import smart_repr


### PR DESCRIPTION
## Changes:
- Removed `django.utils.translation.ugettext_lazy` and use `gettext_lazy`
- Removed `django.utils.encoding.force_text()` and use `force_str`

## Reference
- See [Features Removed in Django 4.0 release](https://docs.djangoproject.com/en/4.0/releases/4.0/#features-removed-in-4-0)
    - `django.utils.translation.ugettext_lazy()` was removed
    - `django.utils.encoding.force_text()` was removed