### PR TITLE
Feature pyproject conf

### DIFF
--- a/hammock/metadata.py
+++ b/hammock/metadata.py
@@ -1,6 +1,6 @@
 """Metadata classes."""
 
-from collections import Callable
+from collections.abc import Callable
 from collections import defaultdict
 from collections import OrderedDict
 


### PR DESCRIPTION
Related issue: https://github.com/Zbooni/zbooni-backend/issues/3927
```
/var/zbooni/src/hammock/hammock/metadata.py:3: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3, and in 3.10 it will stop working
  from collections import Callable
```
related commit: https://github.com/Zbooni/zbooni-backend/pull/3955/commits/ad6dea12138cf1737971df41d7649befbca4aee2